### PR TITLE
Making the runroot more configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,6 +69,19 @@ kojid_compose_user_list:
 kojid_image_builder: False
 kojid_runroot_builder: False
 
+kojid_runroot_mounts:
+  - name: path0
+    mountpoint: /compose
+    path: /compose
+    fstype: bind
+    options: bind
+  - name: path1
+    mountpoint: /mnt/koji
+    path: /mnt/koji
+    fstype: bind
+    options: bind
+
+
 # Zabbix config
 zabbix_kojid_templates:
   - Template CentOS Koji builder

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,12 +81,13 @@
 - name: get the current default route
   command: "/usr/sbin/ip route show 0.0.0.0/0"
   register: default_route
+  when: not ansible_check_mode
   tags:
     - route
 
 - name: delete the default route if it is not localhost
   command: "/usr/sbin/ip route del default"
-  when: not '127.0.0.1' in default_route.stdout and kojid_set_default_nullroute
+  when: not ( default_route is skipped ) and not '127.0.0.1' in default_route.stdout and kojid_set_default_nullroute
   register: delete_default_route
   failed_when:
     - delete_default_route.rc !=0

--- a/templates/runroot.conf.j2
+++ b/templates/runroot.conf.j2
@@ -3,13 +3,13 @@
 ; They will be mounted during each run. It is suggested, that these
 ; paths has readonly options and are made writable via extra_mounts
 ; parameter for individual calls.
-default_mounts = /mnt/koji,/compose
+default_mounts = {{ kojid_runroot_mounts | join(",", attribute='mountpoint') }}
 
 ; comma-delimited list of safe roots.
 ; Each extra_mount need to start with some of these prefixes. Other paths are
 ; not allowed for mounting. Only absolute paths are allowed here, no
 ; wildcards.
-safe_roots = /compose
+safe_roots = /mnt,/compose
 
 ; path substitutions is tuple per line, delimited by comma, order is
 ; important. 
@@ -18,14 +18,11 @@ safe_roots = /compose
 ; path_subs = /mnt/archive/prehistory/,/mnt/prehistoric_disk/archive/prehistory
 
 ; mount origins, order is important here, ordered by best catch
-[path0]
-mountpoint = /compose
-path = /compose
-fstype = bind
-options = bind
 
-[path1]
-mountpoint = /mnt/koji
-path = /mnt/koji
-fstype = bind
-options = bind
+{% for mp in kojid_runroot_mounts %}
+[{{ mp.name }}]
+mountpoint = {{ mp.mountpoint }}
+path = {{ mp.path }}
+fstype = {{ mp.fstype }}
+options = {{ mp.options}}
+{% endfor %}


### PR DESCRIPTION
@arrfab this is running in the Stream environment, and it applies OK in check mode against mbox and cbs. But I wanted to propose this as a PR for review.