### PR TITLE
Set mousetype to usb

### DIFF
--- a/templates/oz.cfg.j2
+++ b/templates/oz.cfg.j2
@@ -11,6 +11,7 @@ image_type = raw
 # bridge_name = virbr0
 cpus = 4
 memory = 4096
+mousetype = usb
 
 [cache]
 original_media = yes


### PR DESCRIPTION
Currently ppc64le image builds are failling because mousetype defaults to ps2.
Change it to usb

Signed-off-by: Troy Dawson <tdawson@redhat.com>