### PR TITLE
We always want to build against the latest in a mock environment

### DIFF
--- a/templates/etc/mock/site-defaults.cfg.j2
+++ b/templates/etc/mock/site-defaults.cfg.j2
@@ -6,3 +6,5 @@ config_opts['use_bootstrap'] = False
 {% if kojid_ulimits_conf %}
 config_opts['nspawn_args'] += ['--rlimit=RLIMIT_NOFILE={{ kojid_ulimits_nofiles }}']
 {% endif %}
+
+config_opts['dnf_disable_plugins'] = ['versionlock'] 


### PR DESCRIPTION
The builders may have certain packages versionlocked in the host dnf.conf setup (example: we wanted to pin the builders on a certain version of ansible-core). This causes trouble in a mock root because it inherits the builders dnf configuration when trying to fill out a buildroot.

When running mock, we should always disable the versionlock plugin so that mockroots get the latest builds from koji.

Fixes: CS-1707